### PR TITLE
Improve AspectJ Maven setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,8 @@
         <awaitility.version>4.2.0</awaitility.version>
         <testcontainer.version>1.18.0</testcontainer.version>
         <!--project plugin dependencies-->
-        <aspect.compiler.plugin.version>1.14.0</aspect.compiler.plugin.version>
+        <aspect.compiler.plugin.version>1.13.1</aspect.compiler.plugin.version>
+        <aspectj.version>1.9.20-SNAPSHOT</aspectj.version>
         <surefire.plugin.version>3.0.0-M7</surefire.plugin.version>
     </properties>
 
@@ -167,6 +168,22 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Make sure that all AspectJ dependencies use the same version  -->
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjtools</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjweaver</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -174,11 +191,11 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspect.compiler.plugin.version}</version>
                 <configuration>
-                    <complianceLevel>15</complianceLevel>
+                    <complianceLevel>${maven.compiler.target}</complianceLevel>
                     <showWeaveInfo>true</showWeaveInfo>
                     <Xlint>ignore</Xlint>
                     <encoding>UTF-8</encoding>
@@ -191,6 +208,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Use AspectJ.dev plugin, because it supports Java 17+
- Use compliance level 17, just like Maven Compiler
- Use AspectJ 1.9.20-SNAPSHOT with fix for problem raised in https://stackoverflow.com/q/76450431/1082681